### PR TITLE
fix "ps_files_cleanup_dir: Permission denied"

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -499,6 +499,10 @@ override_dh_install: rename-files-stamp remove-files-stamp prepare-fpm-pools
 	$(SED) -e'/memory_limit =/ s/128M/-1/g;' \
 	    -e'/session.gc_probability =/ s/1/0/g' \
 	  > debian/$(PHP_COMMON)/usr/lib/php/$(PHP_NAME_VERSION)/php.ini-production.cli
+	  
+	cat php.ini-production | tr "\t" " " | \
+	$(SED) -e'/session.gc_probability =/ s/1/0/g' \
+	  > debian/$(PHP_COMMON)/usr/lib/php/$(PHP_NAME_VERSION)/php.ini-production.fpm
 
 	cat php.ini-development | tr "\t" " " | \
 	$(SED) -e'/session.gc_probability =/ s/1/0/g;' \


### PR DESCRIPTION
Debian cronjob cleans sessions:
09,39 *     * * *     root   [ -x /usr/lib/php/sessionclean ] && /usr/lib/php/sessionclean

PHP GC can not execute due to /var/lib/phpsessions permissions. And it shouldn't run at all.