### PR TITLE
default php-fpm sock location

### DIFF
--- a/debian/php-fpm.dirs.extra
+++ b/debian/php-fpm.dirs.extra
@@ -1,3 +1,4 @@
 /etc/php/@PHP_VERSION@/fpm/pool.d
 /usr/sbin
 /usr/lib/php/@PHP_VERSION@
+/run/php


### PR DESCRIPTION
fix error for 

> root@20252aeac3ba:/# php-fpm7.0 
[17-Apr-2016 16:00:09] ERROR: unable to bind listening socket for address '/run/php/php7.0-fpm.sock': No such file or directory (2)
[17-Apr-2016 16:00:09] ERROR: FPM initialization failed


